### PR TITLE
fix: path for initial code files

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,18 +1,16 @@
 {
-    auto_https disable_redirects
+	auto_https disable_redirects
 }
 
 https://localhost {
-    # Frontend under /s4s
-    handle_path /s4s/* {
-        reverse_proxy frontend:3000
-    }
+	# Frontend under /s4s
+	reverse_proxy /s4s/* frontend:3000
 
-    # Backend API under /s4s/api
-    handle_path /s4s/api/* {
-        # handle_path strips /s4s/api and forwards to Rocket root
-        reverse_proxy backend:8000
-    }
+	# Backend API under /s4s/api
+	handle_path /s4s/api/* {
+		# handle_path strips /s4s/api and forwards to Rocket root
+		reverse_proxy backend:8000
+	}
 
-    tls internal
+	tls internal
 }

--- a/app/src/util/initCodeFiles.tsx
+++ b/app/src/util/initCodeFiles.tsx
@@ -1,5 +1,5 @@
-import { API_URL, FRONTEND_URL } from '@/api/config';
-import { SubmissionLanguage } from '../api/models';
+import { SubmissionLanguage } from "../api/models";
+import config from "@/../next.config.mjs";
 
 export const initFiles: {
   [lang: string]: {
@@ -15,7 +15,7 @@ export const initFiles: {
 export async function getInitialCode(
   lang: SubmissionLanguage
 ): Promise<string> {
-  const path = `${FRONTEND_URL}/base.${initFiles[lang].extension}`;
+  const path = `${config.basePath || ""}/base.${initFiles[lang].extension}`;
   const code = await fetch(path);
   return await code.text();
 }


### PR DESCRIPTION
Accessing files from the `public/` folder should be done by using the app's base URL as prefix (https://nextjs.org/docs/pages/api-reference/file-conventions/public-folder). Also, the reverse proxy must not strip the base URL prefix as this is handled by the app itself.